### PR TITLE
Fix request url in frontend

### DIFF
--- a/static/js/1989.js
+++ b/static/js/1989.js
@@ -7,7 +7,7 @@ let doSubmit = function () {
   data.append("image", f);
   data.append("tilesAcross", tilesAcross);
   data.append("renderedTileSize", renderedTileSize);
-  fetch("/makeMosaic/", {
+  fetch("/makeMosaic", {
     method: "POST",
     body: data,
   })


### PR DESCRIPTION
The url of the current post request in 1989.js is `"/makeMosaic/"`, while the route in the middleware is `"/makeMosaic"`. This leads to a 404 response whenever the user tries to create a mosaic from the frontend. Removing the trailing slash from the request url solves the problem.