### PR TITLE
Cooper Miller (kcm3): MosaicWorker::awaitMMG needs an async requests call to allow for parallel requests #16

### DIFF
--- a/MosaicWorker.py
+++ b/MosaicWorker.py
@@ -5,7 +5,7 @@ import base64
 import httpx
 
 class MosaicWorker:
-  def __init__(self, baseImage, tilesAcross, renderedTileSize, fileFormat, socketio, mmgCount):
+  def __init__(self, baseImage, tilesAcross, renderedTileSize, fileFormat, socketio):
     self.baseImage = baseImage
     self.tilesAcross = tilesAcross
     self.renderedTileSize = renderedTileSize
@@ -22,8 +22,6 @@ class MosaicWorker:
     self.mmgCompleted = 0
     self.reducerCompleted = 0
     self.mosaicNextID = 1
-
-    self.mmgCount = mmgCount
 
   def addMMG(self, mmg):
     self.mmgsAvailable.append(mmg)
@@ -98,7 +96,7 @@ class MosaicWorker:
     print(f"[MosaicWorker]: Sending MMG request to \"{name}\" by {author} at {url}")
 
     try:
-      limits = httpx.Limits(max_keepalive_connections=self.mmgCount, max_connections=None, keepalive_expiry=30)
+      limits = httpx.Limits(max_keepalive_connections=10, max_connections=None, keepalive_expiry=30)
       async with httpx.AsyncClient(limits=limits, timeout=30.0) as client:
         req = await client.post(
             f"{url}?tilesAcross={self.tilesAcross}&renderedTileSize={self.renderedTileSize}&fileFormat={self.fileFormat}",

--- a/MosaicWorker.py
+++ b/MosaicWorker.py
@@ -5,7 +5,7 @@ import base64
 import httpx
 
 class MosaicWorker:
-  def __init__(self, baseImage, tilesAcross, renderedTileSize, fileFormat, socketio, mmg_count):
+  def __init__(self, baseImage, tilesAcross, renderedTileSize, fileFormat, socketio, mmgCount):
     self.baseImage = baseImage
     self.tilesAcross = tilesAcross
     self.renderedTileSize = renderedTileSize
@@ -23,7 +23,7 @@ class MosaicWorker:
     self.reducerCompleted = 0
     self.mosaicNextID = 1
 
-    self.mmg_count = mmg_count
+    self.mmgCount = mmgCount
 
   def addMMG(self, mmg):
     self.mmgsAvailable.append(mmg)
@@ -98,7 +98,7 @@ class MosaicWorker:
     print(f"[MosaicWorker]: Sending MMG request to \"{name}\" by {author} at {url}")
 
     try:
-      limits = httpx.Limits(max_keepalive_connections=self.mmg_count, max_connections=None, keepalive_expiry=30)
+      limits = httpx.Limits(max_keepalive_connections=self.mmgCount, max_connections=None, keepalive_expiry=30)
       async with httpx.AsyncClient(limits=limits, timeout=30.0) as client:
         req = await client.post(
             f"{url}?tilesAcross={self.tilesAcross}&renderedTileSize={self.renderedTileSize}&fileFormat={self.fileFormat}",

--- a/MosaicWorker.py
+++ b/MosaicWorker.py
@@ -2,9 +2,10 @@ import asyncio
 import requests
 import random
 import base64
+import httpx
 
 class MosaicWorker:
-  def __init__(self, baseImage, tilesAcross, renderedTileSize, fileFormat, socketio):
+  def __init__(self, baseImage, tilesAcross, renderedTileSize, fileFormat, socketio, mmg_count):
     self.baseImage = baseImage
     self.tilesAcross = tilesAcross
     self.renderedTileSize = renderedTileSize
@@ -21,6 +22,8 @@ class MosaicWorker:
     self.mmgCompleted = 0
     self.reducerCompleted = 0
     self.mosaicNextID = 1
+
+    self.mmg_count = mmg_count
 
   def addMMG(self, mmg):
     self.mmgsAvailable.append(mmg)
@@ -95,12 +98,14 @@ class MosaicWorker:
     print(f"[MosaicWorker]: Sending MMG request to \"{name}\" by {author} at {url}")
 
     try:
-      req = requests.post(
-          f"{url}?tilesAcross={self.tilesAcross}&renderedTileSize={self.renderedTileSize}&fileFormat={self.fileFormat}",
-          files={"image": self.baseImage}
-      )
-    except requests.exceptions.ConnectionError as e:
-      mmg["error"] = "ConnectionError"
+      limits = httpx.Limits(max_keepalive_connections=self.mmg_count, max_connections=None, keepalive_expiry=30)
+      async with httpx.AsyncClient(limits=limits, timeout=30.0) as client:
+        req = await client.post(
+            f"{url}?tilesAcross={self.tilesAcross}&renderedTileSize={self.renderedTileSize}&fileFormat={self.fileFormat}",
+            files={"image": self.baseImage}
+        )
+    except httpx.RequestError as e:
+      mmg["error"] = "RequestError"
       return
 
     mosaicImage = req.content

--- a/app.py
+++ b/app.py
@@ -95,7 +95,6 @@ async def POST_makeMosaic():
             renderedTileSize = request.form["renderedTileSize"],
             fileFormat = request.form["fileFormat"],
             socketio = socketio,
-            mmgCount = len(mmg_servers),
         )
         for id in mmg_servers:
             worker.addMMG( mmg_servers[id] )

--- a/app.py
+++ b/app.py
@@ -95,7 +95,7 @@ async def POST_makeMosaic():
             renderedTileSize = request.form["renderedTileSize"],
             fileFormat = request.form["fileFormat"],
             socketio = socketio,
-            mmg_count = len(mmg_servers),
+            mmgCount = len(mmg_servers),
         )
         for id in mmg_servers:
             worker.addMMG( mmg_servers[id] )

--- a/app.py
+++ b/app.py
@@ -95,6 +95,7 @@ async def POST_makeMosaic():
             renderedTileSize = request.form["renderedTileSize"],
             fileFormat = request.form["fileFormat"],
             socketio = socketio,
+            mmg_count = len(mmg_servers),
         )
         for id in mmg_servers:
             worker.addMMG( mmg_servers[id] )

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ flask[async]
 requests
 python-dotenv
 flask_socketio
+httpx


### PR DESCRIPTION
## Overview
Used the asynchronous HTTP library `httpx` to address Issue #16 

## Changes
`MosaicWorker.py`
1.  Imported the `httpx` library
2. Added a new parameter `mmgCount` to the `MosaicWorker` class constructor
3. Modified the `awaitMMG` method by replacing the `requests.post` with an asynchronous `httpx.post` call using `httpx.AsyncClient` (also used the `mmgCount` for setting the parallel connection limit).

`app.py`
1. Updated the creation of the `MosaicWorker` instance in `app.py` to pass the number of MMGs:

## Possible Issues
I'm not too sure what the optimal pool limit and timeout configurations are, so I set them almost arbitrarily. This should be checked before merging this PR
