### PR TITLE
Fix header appearance

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -5,8 +5,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>CS 340 Pixel Board</title>
-
+  <title>CS 340: 1989!</title>
+  <link rel="icon" href="../static/favicon.png">
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous" />


### PR DESCRIPTION
This is purely an aesthetic change. The header of the tab (where the favicon is displayed) is currently missing, and the title of the page is wrong, too. I believe the current title is the name of _last year's_ project?

Anyway, this PR fixes that!

Before:

<img width="207" alt="Screenshot 2023-05-04 at 9 46 48 PM" src="https://user-images.githubusercontent.com/60557827/236369393-5682277a-4735-4756-b55a-fe7a3d7ece01.png">

After:

<img width="165" alt="image" src="https://user-images.githubusercontent.com/60557827/236369362-1b0b9ea2-26aa-49e7-aace-b7ee09d70a92.png">
