### PR TITLE
Cooper Miller (kcm3): Have the servers/reducers data (optionally) stored in a database to allow app restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ temp-*
 .DS_Store
 .vscode
 __pycache__
+instance

--- a/app.py
+++ b/app.py
@@ -68,13 +68,12 @@ def PUT_addMMG():
     if existing_mmg:
         id = existing_mmg.id
         count = existing_mmg.count
-    else:
-        # Check for existing MMG with same URL in memory:
-        for existingId in mmg_servers:
-            if mmg_servers[existingId]["url"] == url:
-                id = existingId
-                count = mmg_servers[existingId]["count"]
-                break
+    # Check for existing MMG with same URL in memory:
+    for existingId in mmg_servers:
+        if mmg_servers[existingId]["url"] == url:
+            id = existingId
+            count = mmg_servers[existingId]["count"]
+            break
 
     mmg_servers[id] = {
         "id": id,
@@ -110,13 +109,11 @@ def PUT_registerReducer():
     if existing_reducer:
         id = existing_reducer.id
         count = existing_reducer.count
-    else:
-        # Check for existing Reducer with same URL in memory:
-        for existingId in reducers:
-            if reducers[existingId]["url"] == url:
-                id = existingId
-                count = reducers[existingId]["count"]
-                break
+    # Check for existing Reducer with same URL in memory:
+    for existingId in reducers:
+        if reducers[existingId]["url"] == url:
+            id = existingId
+            break
 
     reducers[id] = {
         "id": id,

--- a/app.py
+++ b/app.py
@@ -63,7 +63,7 @@ def PUT_addMMG():
     id = secrets.token_hex(20)
     count = 0
 
-    # Check for existing MMG with same URL:
+    # Check for existing MMG with same URL in DB:
     existing_mmg = MMG.query.filter_by(url=url).first()
     if existing_mmg:
         id = existing_mmg.id
@@ -104,7 +104,7 @@ def PUT_registerReducer():
     id = secrets.token_hex(20)
     count = 0
 
-    # Check for existing Reducer with same URL:
+    # Check for existing Reducer with same URL in DB:
     existing_reducer = Reducer.query.filter_by(url=url).first()
     if existing_reducer:
         id = existing_reducer.id
@@ -113,6 +113,7 @@ def PUT_registerReducer():
     for existingId in reducers:
         if reducers[existingId]["url"] == url:
             id = existingId
+            count = reducers[existingId]["count"]
             break
 
     reducers[id] = {

--- a/app.py
+++ b/app.py
@@ -185,7 +185,7 @@ def GET_serverList():
 
 @app.route("/uploadData", methods=["POST"])
 def upload_data():
-    """Route to upload data to the server"""
+    """Route to upload data to the database"""
     data_type = request.form.get("type")
     name = request.form.get("name", default=None)
     url = request.form.get("url")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv
 flask_socketio
 httpx
 Pillow
+flask-sqlalchemy

--- a/static/css.css
+++ b/static/css.css
@@ -98,3 +98,20 @@ nav a {
 .server-details td {
   padding: 1px;
 }
+
+.upload-data {
+  font-family: 'Share Tech Mono', monospace; 
+  background-color: #DD3403;
+  border: none;
+  color: white;
+  padding: 8px 16px;
+  text-align: center;
+  font-size: 10px;
+  margin: 2px 2px;
+  opacity: 0.6;
+  transition: 0.3s;
+  display: inline-block;
+  text-decoration: none;
+  cursor: pointer;
+}
+.upload-data:hover {opacity: 1}

--- a/templates/servers.html
+++ b/templates/servers.html
@@ -61,6 +61,7 @@
           <th scope="col">Author</th>
           <th scope="col">Count</th>
           <th scope="col">Error</th>
+          <th scope="col">Database</th>
         </tr>
       </thead>
       <tbody>
@@ -85,6 +86,41 @@
           <td>
             {% if "error" in server %}
             {{ server["error"] }}
+            {% endif %}
+          </td>
+          <td>
+            {% if "type" in server %}
+            <button class="upload-data" onclick="
+              (async () => {
+                const formData = new FormData();
+                formData.append('type', 'reducer');
+                formData.append('url', '{{ server.url }}');
+                formData.append('author', '{{ server.author }}');
+                formData.append('count', '{{ server.count }}');
+                const response = await fetch('/uploadData', { method: 'POST', body: formData });
+                const jsonResponse = await response.json();
+                alert(jsonResponse.message);
+              })()
+            ">
+              Upload
+            </button>
+            {% else %}
+            <button class="upload-data" onclick="
+              (async () => {
+                const formData = new FormData();
+                formData.append('type', 'mmg');
+                formData.append('name', '{{ server.name }}');
+                formData.append('url', '{{ server.url }}');
+                formData.append('author', '{{ server.author }}');
+                formData.append('count', '{{ server.count }}');
+                formData.append('tileImageCount', '{{ server.tiles }}');
+                const response = await fetch('/uploadData', { method: 'POST', body: formData });
+                const jsonResponse = await response.json();
+                alert(jsonResponse.message);
+              })()
+            ">
+              Upload
+            </button>
             {% endif %}
           </td>
         </tr>


### PR DESCRIPTION
Still a WIP I think, but this rough implementation of an SQLite DB to address issue #22 

## Overview
An SQLite database used for storing the mmg and reducer information. The `flask-sqlalchemy` package is used to interact with the database. 

### DB Models
`MMG` Columns: ID, Name, URL, Author, Tiles, Count
`Reducer` Columns: ID, URL, Author, Count

## Uploading Data
A new route, `/uploadData`, was added to allow users to upload MMG and reducer information to the database. This route accepts a POST request with the required fields (type, name, URL, author, tileImageCount, and count for MMGs) and stores the data in the database.  A new button was also added to the server list page for all MMGs and reducers. When clicked, it sends a request to the `/uploadData` route with the necessary information to store the MMG or reducer in the database.

## Other Changes
The `PUT_addMMG()` and `PUT_registerReducer()` routes now check for existing MMGs and reducers with the same URL in the database. **I don't know if this is implemented correctly!** The functions currently check for existing MMGs/reducers in both the DB _and_ the `mmg_servers` and `reducers` dictionaries. The dictionaries are checked second, so if they contain information about the servers then that data takes precedence over the data in the DB


Let me know if there is anything I should change!